### PR TITLE
SetPlayerBaubleInfoWithSlot新增autoRefresh参数

### DIFF
--- a/behavior_pack_Platinum/Script_Platinum/Script_Main/broadcasterServer.py
+++ b/behavior_pack_Platinum/Script_Platinum/Script_Main/broadcasterServer.py
@@ -84,7 +84,7 @@ class BroadcasterServer(serverApi.GetServerSystemCls()):
         BaubleServerService.access().setBaubleSlotInfo(playerId, newBaubleDict)
 
     @staticmethod
-    def SetPlayerBaubleInfoWithSlot(playerId, baubleInfo, slotName):
+    def SetPlayerBaubleInfoWithSlot(playerId, baubleInfo, slotName, autoRefresh=True):
         """
         设置玩家饰品信息
         :param playerId: 玩家ID
@@ -93,10 +93,11 @@ class BroadcasterServer(serverApi.GetServerSystemCls()):
         :type baubleInfo: dict
         :type playerId: str
         :type slotName: str
+        :type autoRefresh: bool
         :return:
         """
         slotName = oldSlotIdFixer(slotName)
-        BaubleServerService.access().setBaubleSlotInfoBySlotId(playerId, slotName, baubleInfo)
+        BaubleServerService.access().setBaubleSlotInfoBySlotId(playerId, slotName, baubleInfo, autoRefresh)
 
     @staticmethod
     def DecreaseBaubleDurability(playerId, slotName, num=1):

--- a/behavior_pack_Platinum/Script_Platinum/Script_UI/baubleClient.py
+++ b/behavior_pack_Platinum/Script_Platinum/Script_UI/baubleClient.py
@@ -90,9 +90,11 @@ class BaubleBroadcastService(BaseService):
         BaubleDataController.setAllBaubleInfo(baubleSlotInfo)
 
     @BaseService.REG_API("platinum/setBaubleSlotInfoBySlotId")
-    def setBaubleSlotInfoBySlotId(self, slotId, baubleSlotInfo):
+    def setBaubleSlotInfoBySlotId(self, slotId, baubleSlotInfo, autoRefresh=True):
         oldBaubleInfo = BaubleDataController.getBaubleInfo(slotId)
         if BaubleDataController.setBaubleInfo(slotId, baubleSlotInfo):
+            if not autoRefresh:
+                return
             if oldBaubleInfo:
                 self.onBaubleTakeOff(oldBaubleInfo, slotId)
             if baubleSlotInfo:

--- a/behavior_pack_Platinum/Script_Platinum/Script_UI/baubleServer.py
+++ b/behavior_pack_Platinum/Script_Platinum/Script_UI/baubleServer.py
@@ -127,11 +127,11 @@ class BaubleServerService(BaseService):
             self.syncRequest(playerId, "platinum/setBaubleSlotInfo", QRequests.Args(baubleSlotInfo))
 
     # 设置特定饰品栏信息
-    def setBaubleSlotInfoBySlotId(self, playerId, slotId, baubleSlotInfo):
+    def setBaubleSlotInfoBySlotId(self, playerId, slotId, baubleSlotInfo, autoRefresh=True):
         baubleSlotType = BaubleSlotServerService.access().getBaubleSlotTypeBySlotIdentifier(slotId)
         success = BaubleServerService.access().checkBaubleAvailable(baubleSlotType, baubleSlotInfo.get("newItemName"))
         if success:
-            self.syncRequest(playerId, "platinum/setBaubleSlotInfoBySlotId", QRequests.Args(slotId, baubleSlotInfo))
+            self.syncRequest(playerId, "platinum/setBaubleSlotInfoBySlotId", QRequests.Args(slotId, baubleSlotInfo, autoRefresh))
         else:
             logging.error("铂: 饰品 {} 无法安装至槽位 {} 请检查饰品注册".format(baubleSlotInfo["newItemName"], slotId))
 


### PR DESCRIPTION
该参数默认为True因此是向下兼容状态。指定该参数可选择是否在设置玩家饰品栏时，是否自动触发onBaubleTakeOff和onBaublePutOn的回调函数。